### PR TITLE
updated the lowerCount error message format

### DIFF
--- a/lib/detergent.js
+++ b/lib/detergent.js
@@ -13,7 +13,8 @@ function expose(methods, results) {
       error += "🔮 " + method + ": " + message + " ⛈ current count: " + occurance + "; max allowed: "+ allowed + "\n";
     }
     if (occurance < allowed) {
-      error += "🔮 " + method + ": " + message + " ✨ current count: " + occurance + "; allowed: "+ allowed + "; don't forget to update the count in .detergentrc\n";
+      var belowCountMessage = "👍 Thanks for removing a `" + method + "`. Please update the `allowedCount` to " + occurance + " in `.detergentrc`";
+      error += "🔮 " + method + ": " + belowCountMessage;
     }
   }
   if (error !== "") {

--- a/test-fixtures/bad/bad.js
+++ b/test-fixtures/bad/bad.js
@@ -3,3 +3,5 @@ blah.foo(3);
 blah.boo(1);
 blah.boo(1);
 blah.boo(1);
+blah.htmlSafe(1);
+blah.htmlSafe(3);

--- a/test-fixtures/config/good/.lower-detergentrc.js
+++ b/test-fixtures/config/good/.lower-detergentrc.js
@@ -1,8 +1,8 @@
 module.exports = {
   methods: {
-   'foo': {
+   'htmlSafe': {
       allowed: 5,
-      message: "foo is bad"
+      message: "Please avoid using `htmlSafe` in our app"
     }
   }
 };

--- a/test/unit/detergent-test.js
+++ b/test/unit/detergent-test.js
@@ -36,6 +36,6 @@ describe("detergent", function() {
     expect(() => Detergent.clean({
       configPath: testConfig,
       files: ['test-fixtures/bad']
-    })).to.throw("🔮 foo: foo is bad ✨ current count: 2; allowed: 5; don't forget to update the count in .detergentrc\n");
+    })).to.throw("🔮 htmlSafe: 👍 Thanks for removing a `htmlSafe`. Please update the `allowedCount` to 2 in `.detergentrc`");
   });
 });


### PR DESCRIPTION
part of https://github.com/intercom/ember-cli-detergent/issues/12

before:

```
🔮 htmlSafe: htmlSafe is bad ✨ current count: 2; allowed: 5; don't forget to update the count in .detergentrc
```

after:

```
🔮 htmlSafe: 👍 Thanks for removing a `htmlSafe`. Please update the `allowedCount` to 2 in `.detergentrc`
```