### PR TITLE
rename `allowed` to `allowedCount`

### DIFF
--- a/lib/detergent.js
+++ b/lib/detergent.js
@@ -7,12 +7,12 @@ function expose(methods, results) {
   var error = "";
   for (var method in results) {
     var occurance = results[method];
-    var allowed = (typeof methods[method].allowed === 'undefined') ? 0 : methods[method].allowed;
+    var allowedCount = (typeof methods[method].allowedCount === 'undefined') ? 0 : methods[method].allowedCount;
     var message = (typeof methods[method].message === 'undefined') ? "" : methods[method].message;
-    if (occurance > allowed) {
-      error += "🔮 " + method + ": " + message + " ⛈ current count: " + occurance + "; max allowed: "+ allowed + "\n";
+    if (occurance > allowedCount) {
+      error += "🔮 " + method + ": " + message + " ⛈ current count: " + occurance + "; max allowed: "+ allowedCount + "\n";
     }
-    if (occurance < allowed) {
+    if (occurance < allowedCount) {
       var belowCountMessage = "👍 Thanks for removing a `" + method + "`. Please update the `allowedCount` to " + occurance + " in `.detergentrc`";
       error += "🔮 " + method + ": " + belowCountMessage;
     }

--- a/lib/parsers/config-parser.js
+++ b/lib/parsers/config-parser.js
@@ -4,7 +4,7 @@ var logger = console;
 var errorMessage =
   '\nember-cli-detergent accepts a `methods` object with one or more <methodName> children.\n' +
   '  * <methodName> - object - Containing the following `optional` values:\n' +
-  '    * `allowed` - integer - number of allowed occurances of the blacklisted method. Defaults to `0`\n' +
+  '    * `allowedCount` - integer - number of allowed occurances of the blacklisted method. Defaults to `0`\n' +
   '    * `message` - string -  a message to display on error. Defaults to `empty string`';
 
 function isValidConfigObjectFormat(config) {

--- a/test-fixtures/config/good/.default-message-detergentrc.js
+++ b/test-fixtures/config/good/.default-message-detergentrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   methods: {
    'foo': {
-      allowed: 1
+      allowedCount: 1
     }
   }
 };

--- a/test-fixtures/config/good/.detergentrc.js
+++ b/test-fixtures/config/good/.detergentrc.js
@@ -1,11 +1,11 @@
 module.exports = {
   methods: {
    'foo': {
-      allowed: 1,
+      allowedCount: 1,
       message: "foo is bad"
     },
     'boo': {
-      allowed: 1,
+      allowedCount: 1,
       message: "boo is bad too"
     }
   }

--- a/test-fixtures/config/good/.lower-detergentrc.js
+++ b/test-fixtures/config/good/.lower-detergentrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   methods: {
    'htmlSafe': {
-      allowed: 5,
+      allowedCount: 5,
       message: "Please avoid using `htmlSafe` in our app"
     }
   }

--- a/test/unit/parsers/config-parser-test.js
+++ b/test/unit/parsers/config-parser-test.js
@@ -26,11 +26,11 @@ describe("config parser", function() {
     var expected = {
       methods: {
        'foo': {
-          allowed: 1,
+          allowedCount: 1,
           message: "foo is bad"
         },
         'boo': {
-          allowed: 1,
+          allowedCount: 1,
           message: "boo is bad too"
         }
       }


### PR DESCRIPTION
part of https://github.com/intercom/ember-cli-detergent/issues/12

config becomes:

```js
module.exports = {
  methods: {
    'htmlSafe': {
      allowedCount: 26,
      message: 'Please avoid using Em.String.htmlSafe or Computed.htmlSafe \nPlease see: https://foo.bar \n',
    }
  }
};
```